### PR TITLE
add an option to force a fixed size for the barcodes. 

### DIFF
--- a/pdf417gen/encoding.py
+++ b/pdf417gen/encoding.py
@@ -65,8 +65,7 @@ def encode(
 
     if force_rows is not None:
         if force_rows < MIN_ROWS or force_rows > MAX_ROWS:
-            raise ValueError("'force_rows' must be between 3 and 90. Given: %r" % rows)
- 
+            raise ValueError("'force_rows' must be between 3 and 90. Given: %r" % force_rows)
     if security_level < 0 or security_level > 8:
         raise ValueError("'security_level' must be between 1 and 8. Given: %r" % security_level)
 

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -107,6 +107,14 @@ def test_force_binary_encode():
     assert list(encode(text_data, force_binary=True)) == expected
 
 
+def test_force_row_height():
+    # Test forcing a specific row height
+    # short that data will never naturally fill the row height
+    test_data = "?"
+    row_height = 15
+    
+    assert len(encode(test_data, force_rows=row_height, columns=6)) == row_height
+
 def test_encode_macro_single_segment():
     # Test macro PDF417 with only one segment
     test_data = "single segment"


### PR DESCRIPTION
This is expected by for example the SWIS tax form standards (even though it violates the rule about padding words only being on the last row).

Adds a minimal test